### PR TITLE
Extend ExecutorContext Interface for simpler variable access in summary pages

### DIFF
--- a/src/main/java/eu/smesec/cysec/csl/parser/CySeCExecutorContextFactory.java
+++ b/src/main/java/eu/smesec/cysec/csl/parser/CySeCExecutorContextFactory.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static eu.smesec.cysec.csl.parser.Atom.NULL_ATOM;
 
@@ -177,6 +178,17 @@ public class CySeCExecutorContextFactory {
     public Atom getVariable(String name, String context) {
       synchronized (variables) {
         return variables.get(name) == null ? NULL_ATOM : variables.get(name).getVariable(context);
+      }
+    }
+
+    @Override
+    public Map<String, Atom> getVariables(String context) {
+      synchronized (variables) {
+        return variables.entrySet().stream()
+          .filter(kv -> kv.getValue().getVariable(context) != null)
+          .collect(Collectors.toMap(
+            kv -> kv.getKey(),
+            kv -> kv.getValue().getVariable(context)));
       }
     }
 

--- a/src/main/java/eu/smesec/cysec/csl/parser/ExecutorContext.java
+++ b/src/main/java/eu/smesec/cysec/csl/parser/ExecutorContext.java
@@ -22,6 +22,7 @@ package eu.smesec.cysec.csl.parser;
 import eu.smesec.cysec.csl.skills.ScoreFactory;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ExecutorContext {
 
@@ -70,6 +71,13 @@ public interface ExecutorContext {
    */
   Atom getVariable(String name, String context);
 
+  /**
+   * <p>get all variables.</p>
+   * @param context a context for the variable
+   * @return the variable contents mapped to the variable names
+   */
+  Map<String, Atom> getVariables(String context); 
+  
   /***
    * <p>Set a variable content.</p>
    * @param name the name of the variable


### PR DESCRIPTION
Since there is no other way to get all coach variables (e.g. to fill a JSP model for the summary page) the `ExecutorContext` interface was extended.