### PR TITLE
setAnswer Command

### DIFF
--- a/src/main/java/eu/smesec/cysec/csl/parser/CommandSetAnswer.java
+++ b/src/main/java/eu/smesec/cysec/csl/parser/CommandSetAnswer.java
@@ -23,8 +23,8 @@ import eu.smesec.cysec.csl.parser.Atom.AtomType;
 import eu.smesec.cysec.platform.bridge.ILibCal;
 import eu.smesec.cysec.platform.bridge.execptions.CacheException;
 import eu.smesec.cysec.platform.bridge.generated.Answer;
-import eu.smesec.cysec.platform.bridge.generated.Option;
 import eu.smesec.cysec.platform.bridge.generated.Question;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -37,18 +37,43 @@ public class CommandSetAnswer extends Command {
 
     // evaluate parameters
     Atom questionId = checkAtomType(aList.get(0), Arrays.asList(AtomType.STRING), true, coachContext, "questionID");
-    Atom answerValue = checkAtomType(aList.get(1), Arrays.asList(AtomType.STRING, AtomType.NULL), true, coachContext, "answerValue");
+    Atom answerValue = checkAtomType(aList.get(1), Arrays.asList(AtomType.STRING, AtomType.NULL), true, coachContext,
+        "answerValue");
+
+    if (answerValue.getType() != AtomType.STRING || questionId.getType() != AtomType.STRING) {
+      // TODO probably thorw an exception?
+    }
+
+    String value = answerValue.getId(); // use getId over toString since toString adds unnecessary " around the value
+    String qid = questionId.getId();
 
     // determine provided option is selected
     ILibCal cal = coachContext.getCal();
+
     try {
-      Answer answer = cal.getAnswer(coachContext.getFqcn().toString(), questionId);
+      Answer answer = cal.getAnswer(coachContext.getFqcn().toString(), qid);
 
-      // set value
-      answer.setAidList(answerValue.getId());
-      // FIXME: writing does not work
+      if (answer != null) {
+        // update existing
+        // TODO handle Astar
 
-    } catch( CacheException e) {
+        answer.setText(value);
+        cal.updateAnswer(coachContext.getFqcn().getCoachId(), answer);
+      } else {
+        // create new answer
+        answer = new Answer();
+        answer.setQid(qid);
+        answer.setText(value);
+
+        // TODO handle Astar
+        // if (question.getType().startsWith("Astar")) {
+        // answer.setAidList(value);
+        // }
+
+        cal.createAnswer(coachContext.getFqcn().getCoachId(), answer);
+      }
+
+    } catch (CacheException e) {
       throw new ExecutorException("error while setting answer of question");
     }
 


### PR DESCRIPTION
Completed implementation of the `setAnswer` command enables coach developers to set an answer of another question in coach logic (e.g. when in question q1 the option q1o1 is selected, the answer of question q2 can be set to option q2o1). 

*Note* that setting an answer for an Astar question, all previously chosen answers are overwritten. Setting not answers for visible questions (`hidden=false`) might lead to confusion (since a user choice might be overwritten at "any" time).

This PR is in direct connection to another [PR in the platform](https://github.com/cysec-platform/cysec-platform/pull/95) (extending the CAL interface).